### PR TITLE
If nothing selected use contents of file

### DIFF
--- a/neo4j.py
+++ b/neo4j.py
@@ -21,7 +21,10 @@ class Neo4jCommand(sublime_plugin.TextCommand):
       selections = self.view.sel()
       
       #assing text from selection to the query object
-      CYPHER_QUERY["query"] = self.view.substr(selections[0])
+      if self.view.substr(selections[0]):
+        CYPHER_QUERY["query"] = self.view.substr(selections[0])
+      else:
+        CYPHER_QUERY["query"] = self.view.substr(self.view.visible_region())
 
       #convert into proper json
       data = json.dumps(CYPHER_QUERY)


### PR DESCRIPTION
Hey,

On some of the SQL editors that I've used the default behaviour is that if you don't select the query then it will use the contents of the current view and execute that as a query.

I found myself expecting this plugin to work like that and it didn't so hence this commit :)

Let me know what you think.
Mark
